### PR TITLE
fix: tick checkboxes when they are clicked

### DIFF
--- a/src/components/menu.spec.tsx
+++ b/src/components/menu.spec.tsx
@@ -1,6 +1,6 @@
-import { render } from "@testing-library/react";
+import { cleanup, render } from "@testing-library/react";
 import { Provider } from "jotai";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Country } from "../models/country.ts";
 import { rawCountriesAtom } from "../state/atoms.ts";
 import { HydrateAtoms } from "../utils/test.ts";
@@ -12,16 +12,49 @@ const country: Country = {
 	region: "Europe",
 };
 
+const renderMenu = (): ReturnType<typeof render> =>
+	render(
+		<Provider>
+			<HydrateAtoms initialValues={[[rawCountriesAtom, { [country.iso3166]: country }]]}>
+				<Menu fullscreen={false} toggleFullscreen={vi.fn<() => void>()} />
+			</HydrateAtoms>
+		</Provider>,
+	);
+
 describe("menu", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	// Auto-cleanup is not registered as the suite does not run with `globals`.
+	afterEach(() => {
+		cleanup();
+	});
+
 	it("should render", () => {
-		const result = render(
-			<Provider>
-				<HydrateAtoms initialValues={[[rawCountriesAtom, { [country.iso3166]: country }]]}>
-					<Menu fullscreen={false} toggleFullscreen={vi.fn<() => void>()} />
-				</HydrateAtoms>
-			</Provider>,
-		);
+		const result = renderMenu();
 
 		expect(result.asFragment()).toMatchSnapshot();
+	}, 5000);
+
+	it("should tick the checkbox when it is clicked", () => {
+		const result = renderMenu();
+		const checkbox = result.getByLabelText("Visited");
+
+		expect(checkbox).not.toBeChecked();
+
+		checkbox.click();
+
+		expect(checkbox).toBeChecked();
+	}, 5000);
+
+	it("should untick the checkbox when it is clicked again", () => {
+		const result = renderMenu();
+		const checkbox = result.getByLabelText("Visited");
+
+		checkbox.click();
+		checkbox.click();
+
+		expect(checkbox).not.toBeChecked();
 	}, 5000);
 });

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -19,8 +19,10 @@ export const countriesAtom = atom<readonly Country[]>((get) => {
 	const rawCountries = get(rawCountriesAtom);
 	const selectedCountries = get(selectedCountriesAtom);
 
+	// Assign onto a new object rather than onto `c`. Mutating `c` in place would keep the
+	// same object identity, so `memo`'d consumers such as `MenuItem` would never re-render.
 	return Object.values(rawCountries).map((c) =>
-		Object.assign(c, {
+		Object.assign({}, c, {
 			selected: selectedCountries.includes(c.iso3166),
 		}),
 	);


### PR DESCRIPTION
Clicking a country checkbox updated the state correctly but the checkbox never visually filled in.

## Cause

`countriesAtom` built its derived countries with `Object.assign(c, …)`, which returns the **target** object:

```ts
Object.values(rawCountries).map((c) =>
    Object.assign(c, { selected: selectedCountries.includes(c.iso3166) }),
);
```

The array was new on every recompute, but each country object kept its original identity forever — only `selected` was mutated in place. `regionalizer` passes those same references straight through into `region.values`.

`MenuItem` is wrapped in `memo`, so its shallow prop compare (`prevProps.country === nextProps.country`) was **always true** and it never re-rendered.

The visible symptom comes from `checked` being a controlled input. After a click React runs `restoreControlledState`, which re-syncs the DOM node to the `checked` value stored in the last committed props. Since `MenuItem` never re-rendered, those props still held `checked: false` — the boolean was read off `country.selected` and baked in at the previous render. So each click ran:

1. Browser natively ticks the box
2. `toggleCountry` fires, jotai state updates correctly
3. React flushes — `memo` bails out, DOM untouched
4. React restores the input to the stale `checked: false` → box visually un-ticks

Both halves were required to produce the bug; removing either the mutation or the `memo` made it disappear. The globe and progress bars kept working because `regionsAtom` builds new region objects each recompute, which is why the state looked like it was updating — it was.

## Fix

Assign onto a fresh object so the identity changes and `memo` can see the update. Object spread is banned repo-wide by `no-rest-spread-properties` (and `no-map-spread` explicitly recommends `Object.assign`), so this keeps `Object.assign` and only stops using `c` as the target.

This also stops derived `selected` state being written back into `rawCountriesAtom`'s objects, which was quietly polluting the raw source data.

## Tests

Adds regression coverage in `menu.spec.tsx` for ticking and unticking, driven through `Menu` so the `memo` path is actually exercised. Verified the tick test fails on the old code and passes on the new.

The suite does not run with `globals`, so Testing Library's auto-cleanup is never registered; `cleanup()` is now called explicitly between renders so multiple renders in one file don't collide.

## Verification

`tsc --noEmit`, `oxlint --type-aware`, and `oxfmt --check` all pass. Full test suite passes except one pre-existing failure, `globe > should have geojson data for every country in dataset`, which needs `VITE_API_KEY_MAPBOX` to load tiles and fails identically on a clean checkout of `main` — unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_011nUHvgiCAHtD6WQ9c6mrDq)_