### PR TITLE
fix: use approximate bounds comparison in globe tests

### DIFF
--- a/src/components/globe.spec.tsx
+++ b/src/components/globe.spec.tsx
@@ -8,6 +8,11 @@ import { assertDefined, mockMediaQueryList } from "../utils/test";
 import { Globe } from "./globe";
 import type { MapForwardedRef } from "./globe";
 
+// Mapbox derives latitudes from tile coordinates with `Math.atan(Math.exp(…))`, and engines are
+// free to differ in the last place on those calls, so bounds shift by ~1e-14 whenever the bundled
+// Chromium changes. Six decimal places (~5cm) absorbs that while still catching real data changes.
+const BOUNDS_PRECISION = 6;
+
 describe("globe", () => {
 	beforeAll(() => {
 		vi.spyOn(window, "matchMedia").mockImplementation(() => mockMediaQueryList());
@@ -44,8 +49,12 @@ describe("globe", () => {
 				}),
 				`No source features were queryable for ${name}.`,
 			);
+			const [west, south, east, north] = bbox(featureCollection(features));
 			expect.soft(features.length, name).toBeGreaterThanOrEqual(1);
-			expect.soft(bounds, name).toEqual(bbox(featureCollection(features)));
+			expect.soft(bounds?.[0], `${name} (west)`).toBeCloseTo(west, BOUNDS_PRECISION);
+			expect.soft(bounds?.[1], `${name} (south)`).toBeCloseTo(south, BOUNDS_PRECISION);
+			expect.soft(bounds?.[2], `${name} (east)`).toBeCloseTo(east, BOUNDS_PRECISION);
+			expect.soft(bounds?.[3], `${name} (north)`).toBeCloseTo(north, BOUNDS_PRECISION);
 		}
 	}, 30_000);
 });


### PR DESCRIPTION
## Summary
Updated the globe component tests to use approximate equality checks for bounding box coordinates instead of exact equality, accounting for floating-point precision variations in Mapbox's latitude calculations.

## Key Changes
- Added `BOUNDS_PRECISION` constant set to 6 decimal places (~5cm accuracy) to accommodate engine-specific floating-point differences in `Math.atan(Math.exp(…))` calculations used by Mapbox
- Replaced single exact equality assertion with four separate `toBeCloseTo()` assertions for each bounding box coordinate (west, south, east, north)
- Improved test assertion granularity with individual labels for each coordinate to aid debugging

## Implementation Details
The change addresses a known issue where Mapbox derives tile coordinate latitudes using transcendental functions that can vary slightly across JavaScript engines. By using approximate equality with 6 decimal places of precision, the tests remain robust to these minor variations while still catching genuine data changes. The precision level of 6 decimals provides ~5cm accuracy, which is more than sufficient for geographic bounds validation.

https://claude.ai/code/session_01GdzLYiNWfKmzkRDDzBx1Pn