### PR TITLE
feat: add camera undo when deselecting focused countries

### DIFF
--- a/src/components/globe-focus.spec.tsx
+++ b/src/components/globe-focus.spec.tsx
@@ -1,0 +1,103 @@
+import { act, render } from "@testing-library/react";
+import { Provider, createStore } from "jotai";
+import { Map as MapboxMap } from "mapbox-gl";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { MockInstance } from "vitest";
+import type { Country } from "../models/country";
+import { addCountryAtom, rawCountriesAtom, removeCountryAtom } from "../state/atoms";
+import { mockMediaQueryList } from "../utils/test";
+import { Globe } from "./globe";
+
+// The `minZoom` the globe gives the map, which is also the zoom it opens at.
+const MIN_ZOOM = 1.8;
+
+const unitedKingdom: Country = {
+	bounds: [-8.65, 49.87, 1.76, 60.86],
+	iso3166: "GB",
+	name: "United Kingdom",
+	region: "Europe",
+};
+
+const createTestStore = (): ReturnType<typeof createStore> => {
+	const store = createStore();
+	store.set(rawCountriesAtom, { [unitedKingdom.iso3166]: unitedKingdom });
+	return store;
+};
+
+// `Map` loads mapbox asynchronously, so nothing camera related exists on the first render.
+const renderGlobe = async (store: ReturnType<typeof createStore>): Promise<void> => {
+	const { container } = render(
+		<Provider store={store}>
+			<Globe />
+		</Provider>,
+	);
+	await vi.waitUntil(() => container.querySelector(".mapboxgl-canvas-container"), {
+		timeout: 5000,
+	});
+};
+
+// The map the globe holds is private to it, so a spied call is the only handle a test has on it.
+const mapBehind = (spy: MockInstance, message: string): MapboxMap => {
+	const [map] = spy.mock.contexts;
+	if (!(map instanceof MapboxMap)) {
+		throw new Error(message);
+	}
+	return map;
+};
+
+// Announces the move a user gesture would make. Mapbox tells its own camera calls apart from
+// gestures by giving only the latter an `originalEvent`, which is the signal the globe reads.
+const dragMap = (map: MapboxMap): void => {
+	map.fire("movestart", { originalEvent: new window.MouseEvent("mousemove", { buttons: 1 }) });
+};
+
+describe("globe focus", () => {
+	beforeAll(() => {
+		vi.spyOn(window, "matchMedia").mockImplementation(() => mockMediaQueryList());
+	});
+
+	afterEach(() => {
+		// `selectedCountriesAtom` is backed by local storage, which outlives an individual store.
+		window.localStorage.clear();
+	});
+
+	it("should return to the previous camera when the focused country is unselected", async () => {
+		const store = createTestStore();
+		const fitBounds = vi.spyOn(MapboxMap.prototype, "fitBounds");
+		const easeTo = vi.spyOn(MapboxMap.prototype, "easeTo");
+		await renderGlobe(store);
+
+		act(() => {
+			store.set(addCountryAtom, unitedKingdom.iso3166);
+		});
+		expect(fitBounds).toHaveBeenCalledWith(unitedKingdom.bounds);
+
+		act(() => {
+			store.set(removeCountryAtom, unitedKingdom.iso3166);
+		});
+		// The globe opens over the null island at its minimum zoom, so that is where an undo lands.
+		expect(easeTo).toHaveBeenCalledWith({
+			bearing: 0,
+			center: { lat: 0, lng: 0 },
+			pitch: 0,
+			zoom: MIN_ZOOM,
+		});
+	}, 10_000);
+
+	it("should keep the camera the user chose when they have moved the map themselves", async () => {
+		const store = createTestStore();
+		const fitBounds = vi.spyOn(MapboxMap.prototype, "fitBounds");
+		const easeTo = vi.spyOn(MapboxMap.prototype, "easeTo");
+		await renderGlobe(store);
+
+		act(() => {
+			store.set(addCountryAtom, unitedKingdom.iso3166);
+		});
+		dragMap(mapBehind(fitBounds, "The globe never asked the map to frame the country."));
+		act(() => {
+			store.set(removeCountryAtom, unitedKingdom.iso3166);
+		});
+
+		expect(easeTo).not.toHaveBeenCalled();
+	}, 10_000);
+});

--- a/src/components/globe.tsx
+++ b/src/components/globe.tsx
@@ -1,9 +1,21 @@
 import { useAtomValue } from "jotai";
-import type { FillExtrusionLayerSpecification, FillLayerSpecification } from "mapbox-gl";
+import type {
+	CameraOptions,
+	FillExtrusionLayerSpecification,
+	FillLayerSpecification,
+} from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import { forwardRef, memo, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import {
+	forwardRef,
+	memo,
+	useCallback,
+	useEffect,
+	useImperativeHandle,
+	useMemo,
+	useRef,
+} from "react";
 import { Layer, Map, NavigationControl, Source } from "react-map-gl/mapbox";
-import type { MapRef } from "react-map-gl/mapbox";
+import type { MapRef, ViewStateChangeEvent } from "react-map-gl/mapbox";
 import { useMatchMedia } from "../hooks/use-match-media";
 import { MapboxLayerKeys, MapboxSourceKeys } from "../models/enums";
 import { focusAtom, selectedCountriesAtom } from "../state/atoms.ts";
@@ -47,13 +59,46 @@ export const Globe = memo(
 			[],
 		);
 
+		// Where the camera sat before the current focus moved it, so an unselect can undo that
+		// move. Held in a ref because it is a detail of this map instance, and reading it should
+		// never trigger a render.
+		const cameraBeforeFocus = useRef<CameraOptions | null>(null);
+
 		useEffect(() => {
-			if (!focus?.bounds) {
+			const { current: map } = internalRef;
+			if (!map || !focus) {
 				return;
 			}
-			const { current: map } = internalRef;
-			map?.fitBounds(focus.bounds);
+			if (focus.type === "undo") {
+				const camera = cameraBeforeFocus.current;
+				// An undo is only good once, and only if we still have somewhere to go back to.
+				cameraBeforeFocus.current = null;
+				if (camera) {
+					map.easeTo(camera);
+				}
+				return;
+			}
+			const { bounds } = focus.country;
+			if (!bounds) {
+				return;
+			}
+			cameraBeforeFocus.current = {
+				bearing: map.getBearing(),
+				center: map.getCenter(),
+				pitch: map.getPitch(),
+				zoom: map.getZoom(),
+			};
+			map.fitBounds(bounds);
 		}, [focus]);
+
+		const handleMoveStart = useCallback((event: ViewStateChangeEvent) => {
+			// Only moves the user made themselves carry an `originalEvent`; the ones we make with
+			// `fitBounds`/`easeTo` do not. Once they have moved the map, they have a view they
+			// chose, and yanking it back to a camera they never asked for would be the surprise.
+			if ("originalEvent" in event && event.originalEvent !== undefined) {
+				cameraBeforeFocus.current = null;
+			}
+		}, []);
 
 		const beenFilter: FillExtrusionLayerSpecification["filter"] = useMemo(
 			() => ["in", ["get", "iso_3166_1"], ["literal", selectedCountries]],
@@ -110,6 +155,7 @@ export const Globe = memo(
 				attributionControl={false}
 				logoPosition="bottom-right"
 				minZoom={minZoom}
+				onMoveStart={handleMoveStart}
 				ref={internalRef}
 				testMode={testMode}
 			>

--- a/src/models/focus.ts
+++ b/src/models/focus.ts
@@ -1,0 +1,9 @@
+import type { Country } from "./country";
+
+/**
+ * What the map's camera should do next.
+ *
+ * `country` frames a country the user has just selected, `undo` puts the camera back where it
+ * was before that framing, so unselecting a country reverses the zoom it caused.
+ */
+export type Focus = { type: "country"; country: Country } | { type: "undo" };

--- a/src/state/atoms.spec.ts
+++ b/src/state/atoms.spec.ts
@@ -1,0 +1,74 @@
+import { createStore } from "jotai";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { Country } from "../models/country";
+import { addCountryAtom, focusAtom, rawCountriesAtom, removeCountryAtom } from "./atoms";
+
+const unitedKingdom: Country = {
+	bounds: [-8.65, 49.87, 1.76, 60.86],
+	iso3166: "GB",
+	name: "United Kingdom",
+	region: "Europe",
+};
+const france: Country = {
+	bounds: [-5.14, 41.33, 9.56, 51.09],
+	iso3166: "FR",
+	name: "France",
+	region: "Europe",
+};
+
+const createTestStore = (): ReturnType<typeof createStore> => {
+	const store = createStore();
+	store.set(rawCountriesAtom, { [unitedKingdom.iso3166]: unitedKingdom, [france.iso3166]: france });
+	return store;
+};
+
+describe("atoms", () => {
+	// `selectedCountriesAtom` is backed by local storage, which outlives an individual store.
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+	afterEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("should focus a country when it is selected", () => {
+		const store = createTestStore();
+
+		store.set(addCountryAtom, unitedKingdom.iso3166);
+
+		// `countriesAtom` decorates the raw country with its selected state before the focus is set.
+		expect(store.get(focusAtom)).toEqual({
+			type: "country",
+			country: Object.assign({}, unitedKingdom, { selected: false }),
+		});
+	}, 5000);
+
+	it("should undo the focus when the focused country is unselected", () => {
+		const store = createTestStore();
+
+		store.set(addCountryAtom, unitedKingdom.iso3166);
+		store.set(removeCountryAtom, unitedKingdom.iso3166);
+
+		expect(store.get(focusAtom)).toEqual({ type: "undo" });
+	}, 5000);
+
+	it("should not undo the focus when another country is unselected", () => {
+		const store = createTestStore();
+
+		store.set(addCountryAtom, france.iso3166);
+		store.set(addCountryAtom, unitedKingdom.iso3166);
+		store.set(removeCountryAtom, france.iso3166);
+
+		expect(store.get(focusAtom)).toBeNull();
+	}, 5000);
+
+	it("should only undo a focus once", () => {
+		const store = createTestStore();
+
+		store.set(addCountryAtom, unitedKingdom.iso3166);
+		store.set(removeCountryAtom, unitedKingdom.iso3166);
+		store.set(removeCountryAtom, unitedKingdom.iso3166);
+
+		expect(store.get(focusAtom)).toBeNull();
+	}, 5000);
+});

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,6 +1,7 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
 import type { Country } from "../models/country.ts";
+import type { Focus } from "../models/focus.ts";
 import type { Region } from "../models/region.ts";
 import { regionalizer } from "../utils/regionalizer.ts";
 
@@ -13,7 +14,7 @@ export const selectedCountriesAtom = atomWithStorage<readonly string[]>(
 	undefined,
 	{ getOnInit: true },
 );
-export const focusAtom = atom<Country | null>();
+export const focusAtom = atom<Focus | null>(null);
 
 export const countriesAtom = atom<readonly Country[]>((get) => {
 	const rawCountries = get(rawCountriesAtom);
@@ -36,14 +37,20 @@ export const addCountryAtom = atom(undefined, (get, set, countryCode: string) =>
 	const selectedCountries = get(selectedCountriesAtom);
 	if (!selectedCountries.includes(countryCode)) {
 		const countries = get(countriesAtom);
-		const focusCountry = countries.find((c) => c.iso3166 === countryCode) ?? undefined;
-		set(focusAtom, focusCountry);
+		const focusCountry = countries.find((c) => c.iso3166 === countryCode);
+		set(focusAtom, focusCountry ? { type: "country", country: focusCountry } : null);
 		set(selectedCountriesAtom, [...selectedCountries, countryCode]);
 	}
 });
 export const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 	const selectedCountries = get(selectedCountriesAtom);
-	set(focusAtom, undefined);
+	const focus = get(focusAtom);
+
+	// Unselecting the country the map is currently framing is an undo of that selection, so ask
+	// the map to go back to where it was rather than leaving the user stranded on a country they
+	// no longer have selected. Unselecting anything else just leaves the camera alone.
+	const undo = focus?.type === "country" && focus.country.iso3166 === countryCode;
+	set(focusAtom, undo ? { type: "undo" } : null);
 	set(
 		selectedCountriesAtom,
 		selectedCountries.filter((c) => c !== countryCode),


### PR DESCRIPTION
## Summary
This PR adds the ability to restore the map's camera position when a user deselects a country that was just focused. When a country is selected, the map frames it and saves the previous camera state. If the user then deselects that same country, the map returns to its previous position instead of leaving the camera stranded.

## Key Changes
- **New `Focus` type model** (`src/models/focus.ts`): Replaces the simple `Country | null` focus with a discriminated union that can represent either focusing on a country or undoing that focus
- **Enhanced focus atom logic** (`src/state/atoms.ts`): 
  - `focusAtom` now uses the new `Focus` type
  - `addCountryAtom` wraps the country in `{ type: "country", country }` format
  - `removeCountryAtom` emits `{ type: "undo" }` only when deselecting the currently focused country
- **Camera state management** (`src/components/globe.tsx`):
  - Saves camera position (bearing, center, pitch, zoom) before framing a focused country
  - Restores the saved camera when an undo focus is triggered
  - Clears the saved camera when the user manually moves the map (detected via `originalEvent` in movestart)
  - Added `onMoveStart` handler to detect user gestures vs. programmatic camera changes
- **Comprehensive test coverage**:
  - `src/state/atoms.spec.ts`: Tests focus atom behavior for selection/deselection scenarios
  - `src/components/globe-focus.spec.tsx`: Tests camera restoration and user gesture detection

## Notable Implementation Details
- The camera before focus is stored in a ref to avoid triggering re-renders
- User gestures are distinguished from programmatic camera changes by checking for `originalEvent` in Mapbox move events
- The undo is single-use: once triggered, the saved camera is cleared to prevent accidental re-triggering
- If a user manually moves the map after a country is focused, the undo is discarded, preserving their chosen view

https://claude.ai/code/session_01BDM5PRKiPZeACxasNoafnx