### PR TITLE
refactor: Extract camera focus and layer logic into custom hooks

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -31,6 +31,7 @@
     "eslint/prefer-object-spread": "off",
     "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "import/exports-last": "off",
+    "import/group-exports": "off",
     "import/no-named-export": "off",
     "import/no-relative-parent-imports": "off",
     "import/no-unassigned-import": ["error", { "allow": ["**/*.css", "**/jest-dom/vitest"] }],

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -28,7 +28,6 @@
     "eslint/no-magic-numbers": "off",
     "eslint/no-ternary": "off",
     "eslint/no-undefined": "off",
-    "eslint/prefer-object-spread": "off",
     "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "import/exports-last": "off",
     "import/group-exports": "off",
@@ -38,6 +37,7 @@
     "import/prefer-default-export": "off",
     "oxc/no-async-await": "off",
     "oxc/no-optional-chaining": "off",
+    "oxc/no-rest-spread-properties": "off",
     "react/function-component-definition": [
       "error",
       { "namedComponents": "arrow-function", "unnamedComponents": "arrow-function" }

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -7,7 +7,7 @@
     "pedantic": "error",
     "perf": "error",
     "restriction": "error",
-    "style": "warn",
+    "style": "error",
     "suspicious": "error"
   },
   "globals": {
@@ -20,11 +20,16 @@
     "@typescript-eslint/dot-notation": "off",
     "@typescript-eslint/prefer-readonly-parameter-types": "warn",
     "@typescript-eslint/strict-void-return": "off",
+    "eslint/capitalized-comments": ["error", "always", { "ignoreConsecutiveComments": true }],
+    "eslint/id-length": ["error", { "checkGeneric": false }],
     "eslint/max-lines-per-function": "off",
     "eslint/no-console": ["error", { "allow": ["warn", "error"] }],
+    "eslint/no-duplicate-imports": ["error", { "allowSeparateTypeImports": true }],
     "eslint/no-magic-numbers": "off",
     "eslint/no-ternary": "off",
     "eslint/no-undefined": "off",
+    "eslint/prefer-object-spread": "off",
+    "eslint/sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "import/exports-last": "off",
     "import/no-named-export": "off",
     "import/no-relative-parent-imports": "off",
@@ -32,8 +37,23 @@
     "import/prefer-default-export": "off",
     "oxc/no-async-await": "off",
     "oxc/no-optional-chaining": "off",
+    "react/function-component-definition": [
+      "error",
+      { "namedComponents": "arrow-function", "unnamedComponents": "arrow-function" }
+    ],
+    "react/jsx-curly-brace-presence": "off",
     "react/jsx-filename-extension": ["error", { "extensions": [".jsx", ".tsx"] }],
-    "react/react-in-jsx-scope": "off"
+    "react/jsx-max-depth": ["error", { "max": 4 }],
+    "react/react-in-jsx-scope": "off",
+    "unicorn/catch-error-name": ["error", { "ignore": ["cause"] }],
+    "unicorn/no-nested-ternary": "off",
+    "unicorn/no-null": "off",
+    "vitest/consistent-test-filename": ["error", { "pattern": ".*\\.spec\\.[tj]sx?$" }],
+    "vitest/no-hooks": ["error", { "allow": ["beforeEach", "afterEach"] }],
+    "vitest/no-importing-vitest-globals": "off",
+    "vitest/prefer-called-times": "off",
+    "vitest/prefer-describe-function-title": "off",
+    "vitest/prefer-strict-boolean-matchers": "off"
   },
   "overrides": [
     {
@@ -52,6 +72,22 @@
       "files": ["src/data/**"],
       "rules": {
         "eslint/max-lines": "off"
+      }
+    },
+    {
+      "files": ["**/*.{ts,tsx}"],
+      "excludeFiles": ["**/*.spec.{ts,tsx}", "src/utils/test.ts", "src/vitest-setup.ts"],
+      "rules": {
+        "vitest/require-hook": "off"
+      }
+    },
+    {
+      "files": ["src/__e2e-test__/**"],
+      "rules": {
+        "vitest/consistent-test-filename": "off",
+        "vitest/no-hooks": "off",
+        "vitest/prefer-expect-assertions": "off",
+        "vitest/prefer-importing-vitest-globals": "off"
       }
     }
   ]

--- a/src/components/app.spec.tsx
+++ b/src/components/app.spec.tsx
@@ -1,14 +1,16 @@
 import { render } from "@testing-library/react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { mockMediaQueryList } from "../utils/test";
 import { App } from "./app";
 
 describe("app", () => {
-	beforeAll(() => {
-		vi.spyOn(window, "matchMedia").mockImplementation(() => mockMediaQueryList());
+	beforeEach(() => {
+		vi.spyOn(globalThis, "matchMedia").mockReturnValue(mockMediaQueryList());
 	});
 
 	it("should render", () => {
+		expect.hasAssertions();
+
 		const result = render(<App />);
 
 		expect(result.asFragment()).toMatchSnapshot();

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -16,7 +16,9 @@ export const App: FC = memo(() => {
 	useEffect(() => {
 		import("../data/countries")
 			.then(({ countries }) => {
-				const countryMap = Object.fromEntries(countries.map((c) => [c.iso3166, c]));
+				const countryMap = Object.fromEntries(
+					countries.map((country) => [country.iso3166, country]),
+				);
 				setRawCountries(countryMap);
 				setLoading(false);
 			})
@@ -26,7 +28,7 @@ export const App: FC = memo(() => {
 	}, [setRawCountries]);
 
 	const reload = useCallback(() => {
-		window.location.reload();
+		globalThis.location.reload();
 	}, []);
 
 	const toggleMenuFullscreen = useCallback(() => {

--- a/src/components/globe-focus.spec.tsx
+++ b/src/components/globe-focus.spec.tsx
@@ -1,7 +1,7 @@
 import { act, render } from "@testing-library/react";
 import { Provider, createStore } from "jotai";
 import { Map as MapboxMap } from "mapbox-gl";
-import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
 import type { Country } from "../models/country";
 import { addCountryAtom, rawCountriesAtom, removeCountryAtom } from "../state/atoms";
@@ -48,20 +48,22 @@ const mapBehind = (spy: MockInstance, message: string): MapboxMap => {
 // Announces the move a user gesture would make. Mapbox tells its own camera calls apart from
 // gestures by giving only the latter an `originalEvent`, which is the signal the globe reads.
 const dragMap = (map: MapboxMap): void => {
-	map.fire("movestart", { originalEvent: new window.MouseEvent("mousemove", { buttons: 1 }) });
+	map.fire("movestart", { originalEvent: new globalThis.MouseEvent("mousemove", { buttons: 1 }) });
 };
 
 describe("globe focus", () => {
-	beforeAll(() => {
-		vi.spyOn(window, "matchMedia").mockImplementation(() => mockMediaQueryList());
+	beforeEach(() => {
+		vi.spyOn(globalThis, "matchMedia").mockReturnValue(mockMediaQueryList());
 	});
 
 	afterEach(() => {
 		// `selectedCountriesAtom` is backed by local storage, which outlives an individual store.
-		window.localStorage.clear();
+		globalThis.localStorage.clear();
 	});
 
 	it("should return to the previous camera when the focused country is unselected", async () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 		const fitBounds = vi.spyOn(MapboxMap.prototype, "fitBounds");
 		const easeTo = vi.spyOn(MapboxMap.prototype, "easeTo");
@@ -85,6 +87,8 @@ describe("globe focus", () => {
 	}, 10_000);
 
 	it("should keep the camera the user chose when they have moved the map themselves", async () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 		const fitBounds = vi.spyOn(MapboxMap.prototype, "fitBounds");
 		const easeTo = vi.spyOn(MapboxMap.prototype, "easeTo");

--- a/src/components/globe.spec.tsx
+++ b/src/components/globe.spec.tsx
@@ -1,8 +1,9 @@
 import { render } from "@testing-library/react";
 import { bbox, featureCollection } from "@turf/turf";
 import { createRef } from "react";
-import { beforeAll, describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { countries } from "../data/countries";
+import type { Country } from "../models/country";
 import { MapboxSourceKeys } from "../models/enums";
 import { assertDefined, mockMediaQueryList } from "../utils/test";
 import { Globe } from "./globe";
@@ -13,18 +14,40 @@ import type { MapForwardedRef } from "./globe";
 // Chromium changes. Six decimal places (~5cm) absorbs that while still catching real data changes.
 const BOUNDS_PRECISION = 6;
 
+const expectCountryBounds = (globe: MapForwardedRef, country: Country): void => {
+	const { iso3166, name, bounds } = country;
+	const features = assertDefined(
+		globe.querySourceFeatures(MapboxSourceKeys.Countries, {
+			filter: ["==", ["get", "iso_3166_1"], iso3166],
+			sourceLayer: "country_boundaries",
+		}),
+		`No source features were queryable for ${name}.`,
+	);
+	expect.soft(features.length, name).toBeGreaterThanOrEqual(1);
+
+	const [west, south, east, north] = bbox(featureCollection(features));
+	expect.soft(bounds?.[0], `${name} (west)`).toBeCloseTo(west, BOUNDS_PRECISION);
+	expect.soft(bounds?.[1], `${name} (south)`).toBeCloseTo(south, BOUNDS_PRECISION);
+	expect.soft(bounds?.[2], `${name} (east)`).toBeCloseTo(east, BOUNDS_PRECISION);
+	expect.soft(bounds?.[3], `${name} (north)`).toBeCloseTo(north, BOUNDS_PRECISION);
+};
+
 describe("globe", () => {
-	beforeAll(() => {
-		vi.spyOn(window, "matchMedia").mockImplementation(() => mockMediaQueryList());
+	beforeEach(() => {
+		vi.spyOn(globalThis, "matchMedia").mockReturnValue(mockMediaQueryList());
 	});
 
 	it("should render", () => {
+		expect.hasAssertions();
+
 		const result = render(<Globe />);
 
 		expect(result.asFragment()).toMatchSnapshot();
 	}, 5000);
 
 	it("should accept a ref", () => {
+		expect.hasAssertions();
+
 		const map = createRef<MapForwardedRef>();
 		const result = render(<Globe ref={map} />);
 
@@ -33,6 +56,8 @@ describe("globe", () => {
 	}, 5000);
 
 	it("should have geojson data for every country in dataset", async () => {
+		expect.hasAssertions();
+
 		const map = createRef<MapForwardedRef>();
 		render(<Globe ref={map} />);
 
@@ -41,20 +66,8 @@ describe("globe", () => {
 		});
 
 		const globe = assertDefined(map.current, "Globe did not attach its forwarded ref.");
-		for (const { iso3166, name, bounds } of countries) {
-			const features = assertDefined(
-				globe.querySourceFeatures(MapboxSourceKeys.Countries, {
-					filter: ["==", ["get", "iso_3166_1"], iso3166],
-					sourceLayer: "country_boundaries",
-				}),
-				`No source features were queryable for ${name}.`,
-			);
-			const [west, south, east, north] = bbox(featureCollection(features));
-			expect.soft(features.length, name).toBeGreaterThanOrEqual(1);
-			expect.soft(bounds?.[0], `${name} (west)`).toBeCloseTo(west, BOUNDS_PRECISION);
-			expect.soft(bounds?.[1], `${name} (south)`).toBeCloseTo(south, BOUNDS_PRECISION);
-			expect.soft(bounds?.[2], `${name} (east)`).toBeCloseTo(east, BOUNDS_PRECISION);
-			expect.soft(bounds?.[3], `${name} (north)`).toBeCloseTo(north, BOUNDS_PRECISION);
+		for (const country of countries) {
+			expectCountryBounds(globe, country);
 		}
 	}, 30_000);
 });

--- a/src/components/globe.tsx
+++ b/src/components/globe.tsx
@@ -1,21 +1,10 @@
 import { useAtomValue } from "jotai";
-import type {
-	CameraOptions,
-	FillExtrusionLayerSpecification,
-	FillLayerSpecification,
-} from "mapbox-gl";
 import "mapbox-gl/dist/mapbox-gl.css";
-import {
-	forwardRef,
-	memo,
-	useCallback,
-	useEffect,
-	useImperativeHandle,
-	useMemo,
-	useRef,
-} from "react";
+import { forwardRef, memo, useImperativeHandle, useRef } from "react";
 import { Layer, Map, NavigationControl, Source } from "react-map-gl/mapbox";
-import type { MapRef, ViewStateChangeEvent } from "react-map-gl/mapbox";
+import type { MapRef } from "react-map-gl/mapbox";
+import { useFocusCamera } from "../hooks/use-focus-camera";
+import { useGlobeLayers } from "../hooks/use-globe-layers";
 import { useMatchMedia } from "../hooks/use-match-media";
 import { MapboxLayerKeys, MapboxSourceKeys } from "../models/enums";
 import { focusAtom, selectedCountriesAtom } from "../state/atoms.ts";
@@ -34,7 +23,7 @@ export interface MapForwardedRef {
 }
 
 export const Globe = memo(
-	forwardRef<MapForwardedRef>((_, ref) => {
+	forwardRef<MapForwardedRef>((_props, ref) => {
 		const internalRef = useRef<MapRef>(null);
 
 		const prefersDark = useMatchMedia("(prefers-color-scheme: dark)");
@@ -47,105 +36,20 @@ export const Globe = memo(
 			() => ({
 				isSourceLoaded: (
 					...params: Parameters<MapRef["isSourceLoaded"]>
-				): ReturnType<MapRef["isSourceLoaded"]> | undefined => {
-					return internalRef.current?.isSourceLoaded(...params);
-				},
+				): ReturnType<MapRef["isSourceLoaded"]> | undefined =>
+					internalRef.current?.isSourceLoaded(...params),
 				querySourceFeatures: (
 					...params: Parameters<MapRef["querySourceFeatures"]>
-				): ReturnType<MapRef["querySourceFeatures"]> | undefined => {
-					return internalRef.current?.querySourceFeatures(...params);
-				},
+				): ReturnType<MapRef["querySourceFeatures"]> | undefined =>
+					internalRef.current?.querySourceFeatures(...params),
 			}),
 			[],
 		);
 
-		// Where the camera sat before the current focus moved it, so an unselect can undo that
-		// move. Held in a ref because it is a detail of this map instance, and reading it should
-		// never trigger a render.
-		const cameraBeforeFocus = useRef<CameraOptions | null>(null);
+		const handleMoveStart = useFocusCamera(internalRef, focus);
 
-		useEffect(() => {
-			const { current: map } = internalRef;
-			if (!map || !focus) {
-				return;
-			}
-			if (focus.type === "undo") {
-				const camera = cameraBeforeFocus.current;
-				// An undo is only good once, and only if we still have somewhere to go back to.
-				cameraBeforeFocus.current = null;
-				if (camera) {
-					map.easeTo(camera);
-				}
-				return;
-			}
-			const { bounds } = focus.country;
-			if (!bounds) {
-				return;
-			}
-			cameraBeforeFocus.current = {
-				bearing: map.getBearing(),
-				center: map.getCenter(),
-				pitch: map.getPitch(),
-				zoom: map.getZoom(),
-			};
-			map.fitBounds(bounds);
-		}, [focus]);
-
-		const handleMoveStart = useCallback((event: ViewStateChangeEvent) => {
-			// Only moves the user made themselves carry an `originalEvent`; the ones we make with
-			// `fitBounds`/`easeTo` do not. Once they have moved the map, they have a view they
-			// chose, and yanking it back to a camera they never asked for would be the surprise.
-			if ("originalEvent" in event && event.originalEvent !== undefined) {
-				cameraBeforeFocus.current = null;
-			}
-		}, []);
-
-		const beenFilter: FillExtrusionLayerSpecification["filter"] = useMemo(
-			() => ["in", ["get", "iso_3166_1"], ["literal", selectedCountries]],
-			[selectedCountries],
-		);
-		const beenPaint: FillLayerSpecification["paint"] = useMemo(
-			() => ({
-				"fill-color": "#fd7e14",
-				"fill-opacity": 0.6,
-			}),
-			[],
-		);
-
-		const buildingsFilter: FillExtrusionLayerSpecification["filter"] = useMemo(
-			() => ["==", "extrude", "true"],
-			[],
-		);
-		const buildingsPaint: FillExtrusionLayerSpecification["paint"] = useMemo(
-			() => ({
-				"fill-extrusion-base": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					15,
-					0,
-					15.05,
-					["get", "min_height"],
-				],
-				"fill-extrusion-color": [
-					"case",
-					["in", ["get", "iso_3166_1"], ["literal", selectedCountries]],
-					"#fd7e14",
-					"#fd7e14",
-				],
-				"fill-extrusion-height": [
-					"interpolate",
-					["linear"],
-					["zoom"],
-					15,
-					0,
-					15.05,
-					["get", "height"],
-				],
-				"fill-extrusion-opacity": 0.6,
-			}),
-			[selectedCountries],
-		);
+		const { beenFilter, beenPaint, buildingsFilter, buildingsPaint } =
+			useGlobeLayers(selectedCountries);
 
 		return (
 			<Map

--- a/src/components/menu-body.tsx
+++ b/src/components/menu-body.tsx
@@ -1,0 +1,63 @@
+import { memo } from "react";
+import type { FC } from "react";
+import type { Region } from "../models/region";
+import { MenuItem } from "./menu-item";
+import { Progress } from "./progress";
+
+interface Props {
+	loading: boolean;
+	regions: readonly Region[];
+}
+
+export const MenuBody: FC<Props> = memo(({ loading, regions }) => {
+	if (loading) {
+		return (
+			<div className="flex size-full items-center justify-center">
+				<svg
+					className="size-5 animate-spin text-neutral-800 dark:text-white"
+					xmlns="http://www.w3.org/2000/svg"
+					fill="none"
+					viewBox="0 0 24 24"
+				>
+					<title>{"Loading!"}</title>
+					<circle
+						className="opacity-25"
+						cx="12"
+						cy="12"
+						r="10"
+						stroke="currentColor"
+						strokeWidth="4"
+					/>
+					<path
+						className="opacity-75"
+						fill="currentColor"
+						d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+					/>
+				</svg>
+			</div>
+		);
+	}
+
+	if (regions.length === 0) {
+		return <div className="m-4 h-full text-center font-medium">{"No results!"}</div>;
+	}
+
+	return (
+		<ul className="h-full overflow-y-auto">
+			{regions.map((region) => (
+				<li key={region.name}>
+					<div className="sticky top-0 flex items-center justify-between bg-zinc-200 p-4 font-medium dark:bg-zinc-800">
+						<h2>{region.name || "Other"}</h2>
+						<Progress complete={region.complete ?? 0} />
+					</div>
+					<ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
+						{region.values.map((country) => (
+							<MenuItem key={country.iso3166} country={country} />
+						))}
+					</ul>
+				</li>
+			))}
+		</ul>
+	);
+});
+MenuBody.displayName = "MenuBody";

--- a/src/components/menu-item.spec.tsx
+++ b/src/components/menu-item.spec.tsx
@@ -4,6 +4,8 @@ import { MenuItem } from "./menu-item";
 
 describe("menuItem", () => {
 	it("should render", () => {
+		expect.hasAssertions();
+
 		const result = render(
 			<MenuItem
 				country={{

--- a/src/components/menu.spec.tsx
+++ b/src/components/menu.spec.tsx
@@ -23,7 +23,7 @@ const renderMenu = (): ReturnType<typeof render> =>
 
 describe("menu", () => {
 	beforeEach(() => {
-		window.localStorage.clear();
+		globalThis.localStorage.clear();
 	});
 
 	// Auto-cleanup is not registered as the suite does not run with `globals`.
@@ -32,12 +32,16 @@ describe("menu", () => {
 	});
 
 	it("should render", () => {
+		expect.hasAssertions();
+
 		const result = renderMenu();
 
 		expect(result.asFragment()).toMatchSnapshot();
 	}, 5000);
 
 	it("should tick the checkbox when it is clicked", () => {
+		expect.hasAssertions();
+
 		const result = renderMenu();
 		const checkbox = result.getByLabelText("Visited");
 
@@ -49,6 +53,8 @@ describe("menu", () => {
 	}, 5000);
 
 	it("should untick the checkbox when it is clicked again", () => {
+		expect.hasAssertions();
+
 		const result = renderMenu();
 		const checkbox = result.getByLabelText("Visited");
 

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -3,8 +3,7 @@ import { memo, useId, useMemo, useState } from "react";
 import type { FC } from "react";
 import type { Region } from "../models/region";
 import { regionsAtom } from "../state/atoms.ts";
-import { MenuItem } from "./menu-item";
-import { Progress } from "./progress";
+import { MenuBody } from "./menu-body";
 
 interface Props {
 	loading?: boolean | undefined;
@@ -19,8 +18,8 @@ export const Menu: FC<Props> = memo(({ loading = false, fullscreen, toggleFullsc
 
 	const [search, setSearch] = useState("");
 	const filteredRegions = useMemo(() => {
-		const s = search.trim().toLowerCase();
-		if (!s) {
+		const searchTerm = search.trim().toLowerCase();
+		if (!searchTerm) {
 			return regions;
 		}
 		return regions
@@ -28,7 +27,7 @@ export const Menu: FC<Props> = memo(({ loading = false, fullscreen, toggleFullsc
 				(region): Region => ({
 					complete: region.complete ?? 0,
 					name: region.name,
-					values: region.values.filter(({ name }) => name.toLowerCase().includes(s)),
+					values: region.values.filter(({ name }) => name.toLowerCase().includes(searchTerm)),
 				}),
 			)
 			.filter((region) => region.values.length > 0);
@@ -47,8 +46,8 @@ export const Menu: FC<Props> = memo(({ loading = false, fullscreen, toggleFullsc
 						type="text"
 						placeholder="Search..."
 						value={search}
-						onChange={(e) => {
-							setSearch(e.target.value);
+						onChange={(event) => {
+							setSearch(event.target.value);
 						}}
 						disabled={loading}
 						aria-labelledby={searchLabelId}
@@ -90,49 +89,7 @@ export const Menu: FC<Props> = memo(({ loading = false, fullscreen, toggleFullsc
 					)}
 				</button>
 			</div>
-			{loading ? (
-				<div className="flex size-full items-center justify-center">
-					<svg
-						className="size-5 animate-spin text-neutral-800 dark:text-white"
-						xmlns="http://www.w3.org/2000/svg"
-						fill="none"
-						viewBox="0 0 24 24"
-					>
-						<title>Loading!</title>
-						<circle
-							className="opacity-25"
-							cx="12"
-							cy="12"
-							r="10"
-							stroke="currentColor"
-							strokeWidth="4"
-						/>
-						<path
-							className="opacity-75"
-							fill="currentColor"
-							d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-						/>
-					</svg>
-				</div>
-			) : filteredRegions.length === 0 ? (
-				<div className="m-4 h-full text-center font-medium">No results!</div>
-			) : (
-				<ul className="h-full overflow-y-auto">
-					{filteredRegions.map((region) => (
-						<li key={region.name}>
-							<div className="sticky top-0 flex items-center justify-between bg-zinc-200 p-4 font-medium dark:bg-zinc-800">
-								<h2>{region.name || "Other"}</h2>
-								<Progress complete={region.complete ?? 0} />
-							</div>
-							<ul className="divide-y divide-zinc-100 dark:divide-zinc-800">
-								{region.values.map((country) => (
-									<MenuItem key={country.iso3166} country={country} />
-								))}
-							</ul>
-						</li>
-					))}
-				</ul>
-			)}
+			<MenuBody loading={loading} regions={filteredRegions} />
 		</>
 	);
 });

--- a/src/components/progress.spec.tsx
+++ b/src/components/progress.spec.tsx
@@ -4,6 +4,8 @@ import { Progress } from "./progress";
 
 describe("progress", () => {
 	it("should render", () => {
+		expect.hasAssertions();
+
 		const result = render(<Progress complete={0} />);
 
 		expect(result.asFragment()).toMatchSnapshot();

--- a/src/hooks/use-focus-camera.ts
+++ b/src/hooks/use-focus-camera.ts
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { RefObject } from "react";
+import type { CameraOptions } from "mapbox-gl";
+import type { MapRef, ViewStateChangeEvent } from "react-map-gl/mapbox";
+import type { Focus } from "../models/focus";
+
+// Frames the focused country, and returns the `onMoveStart` handler that lets the user's own
+// gestures take the camera back off us.
+export const useFocusCamera = (
+	mapRef: RefObject<MapRef | null>,
+	focus: Focus | null,
+): ((event: ViewStateChangeEvent) => void) => {
+	// Where the camera sat before the current focus moved it, so an unselect can undo that
+	// move. Held in a ref because it is a detail of this map instance, and reading it should
+	// never trigger a render.
+	const cameraBeforeFocus = useRef<CameraOptions | null>(null);
+
+	const undoFocus = useCallback((map: MapRef) => {
+		const camera = cameraBeforeFocus.current;
+		// An undo is only good once, and only if we still have somewhere to go back to.
+		cameraBeforeFocus.current = null;
+		if (camera) {
+			map.easeTo(camera);
+		}
+	}, []);
+
+	useEffect(() => {
+		const { current: map } = mapRef;
+		if (!map || !focus) {
+			return;
+		}
+		if (focus.type === "undo") {
+			undoFocus(map);
+			return;
+		}
+		const { bounds } = focus.country;
+		if (bounds) {
+			cameraBeforeFocus.current = {
+				bearing: map.getBearing(),
+				center: map.getCenter(),
+				pitch: map.getPitch(),
+				zoom: map.getZoom(),
+			};
+			map.fitBounds(bounds);
+		}
+	}, [focus, mapRef, undoFocus]);
+
+	return useCallback((event: ViewStateChangeEvent) => {
+		// Only moves the user made themselves carry an `originalEvent`; the ones we make with
+		// `fitBounds`/`easeTo` do not. Once they have moved the map, they have a view they
+		// chose, and yanking it back to a camera they never asked for would be the surprise.
+		if ("originalEvent" in event && event.originalEvent !== undefined) {
+			cameraBeforeFocus.current = null;
+		}
+	}, []);
+};

--- a/src/hooks/use-globe-layers.ts
+++ b/src/hooks/use-globe-layers.ts
@@ -1,0 +1,62 @@
+import { useMemo } from "react";
+import type { FillExtrusionLayerSpecification, FillLayerSpecification } from "mapbox-gl";
+
+type Filter = NonNullable<FillExtrusionLayerSpecification["filter"]>;
+
+export interface GlobeLayers {
+	beenFilter: Filter;
+	beenPaint: NonNullable<FillLayerSpecification["paint"]>;
+	buildingsFilter: Filter;
+	buildingsPaint: NonNullable<FillExtrusionLayerSpecification["paint"]>;
+}
+
+export const useGlobeLayers = (selectedCountries: readonly string[]): GlobeLayers => {
+	const beenFilter: Filter = useMemo(
+		() => ["in", ["get", "iso_3166_1"], ["literal", selectedCountries]],
+		[selectedCountries],
+	);
+	const beenPaint: NonNullable<FillLayerSpecification["paint"]> = useMemo(
+		() => ({
+			"fill-color": "#fd7e14",
+			"fill-opacity": 0.6,
+		}),
+		[],
+	);
+
+	const buildingsFilter: Filter = useMemo(() => ["==", "extrude", "true"], []);
+	const buildingsPaint: NonNullable<FillExtrusionLayerSpecification["paint"]> = useMemo(
+		() => ({
+			"fill-extrusion-base": [
+				"interpolate",
+				["linear"],
+				["zoom"],
+				15,
+				0,
+				15.05,
+				["get", "min_height"],
+			],
+			"fill-extrusion-color": [
+				"case",
+				["in", ["get", "iso_3166_1"], ["literal", selectedCountries]],
+				"#fd7e14",
+				"#fd7e14",
+			],
+			"fill-extrusion-height": [
+				"interpolate",
+				["linear"],
+				["zoom"],
+				15,
+				0,
+				15.05,
+				["get", "height"],
+			],
+			"fill-extrusion-opacity": 0.6,
+		}),
+		[selectedCountries],
+	);
+
+	return useMemo(
+		() => ({ beenFilter, beenPaint, buildingsFilter, buildingsPaint }),
+		[beenFilter, beenPaint, buildingsFilter, buildingsPaint],
+	);
+};

--- a/src/hooks/use-local-storage.spec.ts
+++ b/src/hooks/use-local-storage.spec.ts
@@ -4,6 +4,8 @@ import { useLocalStorage } from "./use-local-storage";
 
 describe("useLocalStorage", () => {
 	it("should initialise", () => {
+		expect.hasAssertions();
+
 		const { result } = renderHook(() => useLocalStorage("TEST", "hello"));
 		const [data, setData] = result.current;
 

--- a/src/hooks/use-match-media.spec.ts
+++ b/src/hooks/use-match-media.spec.ts
@@ -1,16 +1,14 @@
 import { renderHook } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { MockInstance } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { mockMediaQueryList } from "../utils/test";
 import { useMatchMedia } from "./use-match-media";
 
 describe("useMatchMedia", () => {
-	let mockMatchMedia: MockInstance<typeof window.matchMedia>;
-	beforeEach(() => {
-		mockMatchMedia = vi.spyOn(window, "matchMedia").mockReturnValue(mockMediaQueryList());
-	});
-
 	it("should initialise", () => {
+		expect.hasAssertions();
+
+		const mockMatchMedia = vi.spyOn(globalThis, "matchMedia").mockReturnValue(mockMediaQueryList());
+
 		const { result } = renderHook(() => useMatchMedia("(max-width: 1024px)"));
 
 		expect(result.current).toBeFalsy();

--- a/src/hooks/use-match-media.ts
+++ b/src/hooks/use-match-media.ts
@@ -1,4 +1,4 @@
-import { useSyncExternalStore, useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 import { useWindow } from "./use-window";
 
 export const useMatchMedia = (query: string): boolean => {

--- a/src/hooks/use-window.ts
+++ b/src/hooks/use-window.ts
@@ -1,3 +1,1 @@
-export const useWindow = (): Window & typeof globalThis => {
-	return window;
-};
+export const useWindow = (): typeof globalThis => globalThis;

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,10 +1,8 @@
-const MapboxSourceKeys = {
+export const MapboxSourceKeys = {
 	Countries: "countries",
 } as const;
 
-const MapboxLayerKeys = {
+export const MapboxLayerKeys = {
 	Been: "been",
 	Buildings: "buildings",
 } as const;
-
-export { MapboxLayerKeys, MapboxSourceKeys };

--- a/src/models/enums.ts
+++ b/src/models/enums.ts
@@ -1,8 +1,10 @@
-export const MapboxSourceKeys = {
+const MapboxSourceKeys = {
 	Countries: "countries",
 } as const;
 
-export const MapboxLayerKeys = {
+const MapboxLayerKeys = {
 	Been: "been",
 	Buildings: "buildings",
 } as const;
+
+export { MapboxLayerKeys, MapboxSourceKeys };

--- a/src/state/atoms.spec.ts
+++ b/src/state/atoms.spec.ts
@@ -40,7 +40,7 @@ describe("atoms", () => {
 
 		// `countriesAtom` decorates the raw country with its selected state before the focus is set.
 		expect(store.get(focusAtom)).toStrictEqual({
-			country: Object.assign({}, unitedKingdom, { selected: false }),
+			country: { ...unitedKingdom, selected: false },
 			type: "country",
 		});
 	}, 5000);

--- a/src/state/atoms.spec.ts
+++ b/src/state/atoms.spec.ts
@@ -25,34 +25,40 @@ const createTestStore = (): ReturnType<typeof createStore> => {
 describe("atoms", () => {
 	// `selectedCountriesAtom` is backed by local storage, which outlives an individual store.
 	beforeEach(() => {
-		window.localStorage.clear();
+		globalThis.localStorage.clear();
 	});
 	afterEach(() => {
-		window.localStorage.clear();
+		globalThis.localStorage.clear();
 	});
 
 	it("should focus a country when it is selected", () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 
 		store.set(addCountryAtom, unitedKingdom.iso3166);
 
 		// `countriesAtom` decorates the raw country with its selected state before the focus is set.
-		expect(store.get(focusAtom)).toEqual({
-			type: "country",
+		expect(store.get(focusAtom)).toStrictEqual({
 			country: Object.assign({}, unitedKingdom, { selected: false }),
+			type: "country",
 		});
 	}, 5000);
 
 	it("should undo the focus when the focused country is unselected", () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 
 		store.set(addCountryAtom, unitedKingdom.iso3166);
 		store.set(removeCountryAtom, unitedKingdom.iso3166);
 
-		expect(store.get(focusAtom)).toEqual({ type: "undo" });
+		expect(store.get(focusAtom)).toStrictEqual({ type: "undo" });
 	}, 5000);
 
 	it("should not undo the focus when another country is unselected", () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 
 		store.set(addCountryAtom, france.iso3166);
@@ -63,6 +69,8 @@ describe("atoms", () => {
 	}, 5000);
 
 	it("should only undo a focus once", () => {
+		expect.hasAssertions();
+
 		const store = createTestStore();
 
 		store.set(addCountryAtom, unitedKingdom.iso3166);

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -20,13 +20,13 @@ export const countriesAtom = atom<readonly Country[]>((get) => {
 	const rawCountries = get(rawCountriesAtom);
 	const selectedCountries = get(selectedCountriesAtom);
 
-	// Assign onto a new object rather than onto `c`. Mutating `c` in place would keep the
-	// same object identity, so `memo`'d consumers such as `MenuItem` would never re-render.
-	return Object.values(rawCountries).map((country) =>
-		Object.assign({}, country, {
-			selected: selectedCountries.includes(country.iso3166),
-		}),
-	);
+	// Spread into a new object rather than mutating `country`. Mutating it in place would keep
+	// the same object identity, so `memo`'d consumers such as `MenuItem` would never re-render.
+	// oxlint-disable-next-line no-map-spread -- The in-place mutation it suggests is what the new object identity is avoiding.
+	return Object.values(rawCountries).map((country) => ({
+		...country,
+		selected: selectedCountries.includes(country.iso3166),
+	}));
 });
 export const regionsAtom = atom<readonly Region[]>((get) => {
 	const countries = get(countriesAtom);

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -7,16 +7,16 @@ import { regionalizer } from "../utils/regionalizer.ts";
 
 const COUNTRIES_STORAGE_KEY = "APP_COUNTRIES";
 
-const rawCountriesAtom = atom<Record<string, Country>>({});
-const selectedCountriesAtom = atomWithStorage<readonly string[]>(
+export const rawCountriesAtom = atom<Record<string, Country>>({});
+export const selectedCountriesAtom = atomWithStorage<readonly string[]>(
 	COUNTRIES_STORAGE_KEY,
 	[],
 	undefined,
 	{ getOnInit: true },
 );
-const focusAtom = atom<Focus | null>(null);
+export const focusAtom = atom<Focus | null>(null);
 
-const countriesAtom = atom<readonly Country[]>((get) => {
+export const countriesAtom = atom<readonly Country[]>((get) => {
 	const rawCountries = get(rawCountriesAtom);
 	const selectedCountries = get(selectedCountriesAtom);
 
@@ -28,12 +28,12 @@ const countriesAtom = atom<readonly Country[]>((get) => {
 		}),
 	);
 });
-const regionsAtom = atom<readonly Region[]>((get) => {
+export const regionsAtom = atom<readonly Region[]>((get) => {
 	const countries = get(countriesAtom);
 	return regionalizer(countries);
 });
 
-const addCountryAtom = atom(undefined, (get, set, countryCode: string) => {
+export const addCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 	const selectedCountries = get(selectedCountriesAtom);
 	if (!selectedCountries.includes(countryCode)) {
 		const countries = get(countriesAtom);
@@ -42,7 +42,7 @@ const addCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 		set(selectedCountriesAtom, [...selectedCountries, countryCode]);
 	}
 });
-const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
+export const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 	const selectedCountries = get(selectedCountriesAtom);
 	const focus = get(focusAtom);
 
@@ -56,13 +56,3 @@ const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 		selectedCountries.filter((code) => code !== countryCode),
 	);
 });
-
-export {
-	addCountryAtom,
-	countriesAtom,
-	focusAtom,
-	rawCountriesAtom,
-	regionsAtom,
-	removeCountryAtom,
-	selectedCountriesAtom,
-};

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -7,42 +7,42 @@ import { regionalizer } from "../utils/regionalizer.ts";
 
 const COUNTRIES_STORAGE_KEY = "APP_COUNTRIES";
 
-export const rawCountriesAtom = atom<Record<string, Country>>({});
-export const selectedCountriesAtom = atomWithStorage<readonly string[]>(
+const rawCountriesAtom = atom<Record<string, Country>>({});
+const selectedCountriesAtom = atomWithStorage<readonly string[]>(
 	COUNTRIES_STORAGE_KEY,
 	[],
 	undefined,
 	{ getOnInit: true },
 );
-export const focusAtom = atom<Focus | null>(null);
+const focusAtom = atom<Focus | null>(null);
 
-export const countriesAtom = atom<readonly Country[]>((get) => {
+const countriesAtom = atom<readonly Country[]>((get) => {
 	const rawCountries = get(rawCountriesAtom);
 	const selectedCountries = get(selectedCountriesAtom);
 
 	// Assign onto a new object rather than onto `c`. Mutating `c` in place would keep the
 	// same object identity, so `memo`'d consumers such as `MenuItem` would never re-render.
-	return Object.values(rawCountries).map((c) =>
-		Object.assign({}, c, {
-			selected: selectedCountries.includes(c.iso3166),
+	return Object.values(rawCountries).map((country) =>
+		Object.assign({}, country, {
+			selected: selectedCountries.includes(country.iso3166),
 		}),
 	);
 });
-export const regionsAtom = atom<readonly Region[]>((get) => {
+const regionsAtom = atom<readonly Region[]>((get) => {
 	const countries = get(countriesAtom);
 	return regionalizer(countries);
 });
 
-export const addCountryAtom = atom(undefined, (get, set, countryCode: string) => {
+const addCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 	const selectedCountries = get(selectedCountriesAtom);
 	if (!selectedCountries.includes(countryCode)) {
 		const countries = get(countriesAtom);
-		const focusCountry = countries.find((c) => c.iso3166 === countryCode);
-		set(focusAtom, focusCountry ? { type: "country", country: focusCountry } : null);
+		const focusCountry = countries.find((country) => country.iso3166 === countryCode);
+		set(focusAtom, focusCountry ? { country: focusCountry, type: "country" } : null);
 		set(selectedCountriesAtom, [...selectedCountries, countryCode]);
 	}
 });
-export const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
+const removeCountryAtom = atom(undefined, (get, set, countryCode: string) => {
 	const selectedCountries = get(selectedCountriesAtom);
 	const focus = get(focusAtom);
 
@@ -53,6 +53,16 @@ export const removeCountryAtom = atom(undefined, (get, set, countryCode: string)
 	set(focusAtom, undo ? { type: "undo" } : null);
 	set(
 		selectedCountriesAtom,
-		selectedCountries.filter((c) => c !== countryCode),
+		selectedCountries.filter((code) => code !== countryCode),
 	);
 });
+
+export {
+	addCountryAtom,
+	countriesAtom,
+	focusAtom,
+	rawCountriesAtom,
+	regionsAtom,
+	removeCountryAtom,
+	selectedCountriesAtom,
+};

--- a/src/utils/regionalizer.ts
+++ b/src/utils/regionalizer.ts
@@ -13,18 +13,18 @@ export const regionalizer = (countries: readonly Country[]): readonly Region[] =
 
 	return [...regionMap.entries()]
 		.map(([regionName, values]) => ({
-			complete: values.filter((c) => c.selected === true).length / values.length,
+			complete: values.filter((country) => country.selected === true).length / values.length,
 			name: regionName,
-			values: values.toSorted((a, b) => a.name.localeCompare(b.name)),
+			values: values.toSorted((left, right) => left.name.localeCompare(right.name)),
 		}))
-		.toSorted((a, b) => {
-			if (a.name === "") {
+		.toSorted((left, right) => {
+			if (left.name === "") {
 				return 1;
 			}
-			if (b.name === "") {
+			if (right.name === "") {
 				return -1;
 			}
 
-			return a.name.localeCompare(b.name);
+			return left.name.localeCompare(right.name);
 		});
 };

--- a/src/utils/regionalizr.spec.ts
+++ b/src/utils/regionalizr.spec.ts
@@ -5,6 +5,8 @@ import { regionalizer } from "./regionalizer";
 
 describe("regionalizer", () => {
 	it("should correctly group countries by region", () => {
+		expect.hasAssertions();
+
 		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "Region 1" },
 			{ iso3166: "B", name: "Country B", region: "Region 2" },
@@ -36,12 +38,16 @@ describe("regionalizer", () => {
 	}, 5000);
 
 	it("should handle an empty array", () => {
+		expect.hasAssertions();
+
 		const countries: readonly Country[] = [];
 		const result = regionalizer(countries);
 		expect(result).toStrictEqual([]);
 	}, 5000);
 
 	it("should correctly handle single country in each region", () => {
+		expect.hasAssertions();
+
 		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "Region 1" },
 			{ iso3166: "B", name: "Country B", region: "Region 2" },
@@ -71,6 +77,8 @@ describe("regionalizer", () => {
 	}, 5000);
 
 	it("should sort the regions", () => {
+		expect.hasAssertions();
+
 		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "Region 2" },
 			{ iso3166: "B", name: "Country B", region: "Region 3" },
@@ -83,31 +91,39 @@ describe("regionalizer", () => {
 		expect(result[2]?.name).toBe("Region 3");
 	}, 5000);
 
-	it("should sort an empty region name", () => {
-		const countriesA: readonly Country[] = [
+	it("should sort an empty region name last", () => {
+		expect.hasAssertions();
+
+		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "Region 2" },
 			{ iso3166: "B", name: "Country B", region: "" },
 			{ iso3166: "C", name: "Country C", region: "Region 1" },
 		];
 
-		const resultA = regionalizer(countriesA);
-		expect(resultA[0]?.name).toBe("Region 1");
-		expect(resultA[1]?.name).toBe("Region 2");
-		expect(resultA[2]?.name).toBe("");
+		const result = regionalizer(countries);
+		expect(result[0]?.name).toBe("Region 1");
+		expect(result[1]?.name).toBe("Region 2");
+		expect(result[2]?.name).toBe("");
+	}, 5000);
 
-		const countriesB: readonly Country[] = [
+	it("should sort an empty region name last when it is encountered first", () => {
+		expect.hasAssertions();
+
+		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "" },
 			{ iso3166: "B", name: "Country B", region: "Region 1" },
 			{ iso3166: "C", name: "Country C", region: "Region 2" },
 		];
 
-		const resultB = regionalizer(countriesB);
-		expect(resultB[0]?.name).toBe("Region 1");
-		expect(resultB[1]?.name).toBe("Region 2");
-		expect(resultB[2]?.name).toBe("");
+		const result = regionalizer(countries);
+		expect(result[0]?.name).toBe("Region 1");
+		expect(result[1]?.name).toBe("Region 2");
+		expect(result[2]?.name).toBe("");
 	}, 5000);
 
 	it("should not mutate the original array", () => {
+		expect.hasAssertions();
+
 		const countries: readonly Country[] = [
 			{ iso3166: "A", name: "Country A", region: "Region 1" },
 			{ iso3166: "B", name: "Country B", region: "Region 1" },

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -16,7 +16,8 @@ type InferAtomTuples<T> = {
 		: never;
 };
 
-const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...unknown[]])[]>({
+// oxlint-disable-next-line no-export -- This is a test utility file.
+export const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...unknown[]])[]>({
 	initialValues,
 	children,
 }: PropsWithChildren<{
@@ -26,7 +27,8 @@ const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...unknown[
 	return children;
 };
 
-const mockMediaQueryList = (matches = false): MediaQueryList => ({
+// oxlint-disable-next-line no-export -- This is a test utility file.
+export const mockMediaQueryList = (matches = false): MediaQueryList => ({
 	addEventListener: vi.fn<MediaQueryList["addEventListener"]>(),
 	// oxlint-disable-next-line no-deprecated -- Deprecated, but still required by the `MediaQueryList` type.
 	addListener: vi.fn<MediaQueryList["addListener"]>(),
@@ -39,12 +41,10 @@ const mockMediaQueryList = (matches = false): MediaQueryList => ({
 	removeListener: vi.fn<MediaQueryList["removeListener"]>(),
 });
 
-const assertDefined = <T>(value: T | null | undefined, message: string): T => {
+// oxlint-disable-next-line no-export -- This is a test utility file.
+export const assertDefined = <T>(value: T | null | undefined, message: string): T => {
 	if (value === null || value === undefined) {
 		throw new Error(message);
 	}
 	return value;
 };
-
-// oxlint-disable-next-line no-export -- This is a test utility file.
-export { HydrateAtoms, assertDefined, mockMediaQueryList };

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -16,8 +16,7 @@ type InferAtomTuples<T> = {
 		: never;
 };
 
-// oxlint-disable-next-line no-export -- This is a test utility file.
-export const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...unknown[]])[]>({
+const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...unknown[]])[]>({
 	initialValues,
 	children,
 }: PropsWithChildren<{
@@ -27,8 +26,7 @@ export const HydrateAtoms = <T extends readonly (readonly [AnyWritableAtom, ...u
 	return children;
 };
 
-// oxlint-disable-next-line no-export -- This is a test utility file.
-export const mockMediaQueryList = (matches = false): MediaQueryList => ({
+const mockMediaQueryList = (matches = false): MediaQueryList => ({
 	addEventListener: vi.fn<MediaQueryList["addEventListener"]>(),
 	// oxlint-disable-next-line no-deprecated -- Deprecated, but still required by the `MediaQueryList` type.
 	addListener: vi.fn<MediaQueryList["addListener"]>(),
@@ -41,10 +39,12 @@ export const mockMediaQueryList = (matches = false): MediaQueryList => ({
 	removeListener: vi.fn<MediaQueryList["removeListener"]>(),
 });
 
-// oxlint-disable-next-line no-export -- This is a test utility file.
-export const assertDefined = <T>(value: T | null | undefined, message: string): T => {
+const assertDefined = <T>(value: T | null | undefined, message: string): T => {
 	if (value === null || value === undefined) {
 		throw new Error(message);
 	}
 	return value;
 };
+
+// oxlint-disable-next-line no-export -- This is a test utility file.
+export { HydrateAtoms, assertDefined, mockMediaQueryList };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,9 +20,9 @@ export default defineConfig(({ command }) => ({
 		browser: {
 			enabled: true,
 			headless: true,
+			instances: [{ browser: "chromium" }],
 			provider: playwright(),
 			screenshotFailures: false,
-			instances: [{ browser: "chromium" }],
 		},
 		clearMocks: true,
 		coverage: {


### PR DESCRIPTION
## Summary
This PR refactors the Globe component by extracting complex logic into reusable custom hooks and extracting the menu body rendering into a separate component. Additionally, linting rules are tightened and code style improvements are made throughout the codebase.

## Key Changes

### Component & Hook Extraction
- **New hook `useFocusCamera`**: Extracted camera focus logic from Globe component, handling country framing and undo functionality
- **New hook `useGlobeLayers`**: Extracted Mapbox layer configuration (filters and paint styles) into a dedicated hook
- **New component `MenuBody`**: Extracted menu body rendering logic (loading state, empty state, region/country list) from Menu component

### Code Quality Improvements
- Tightened linting rules in `.oxlintrc.json`:
  - Changed `style` from warn to error
  - Added rules for capitalized comments, import sorting, duplicate imports, and React component definitions
  - Added vitest-specific rules for test consistency
- Improved variable naming throughout (e.g., `c` → `country`, `s` → `searchTerm`, `e` → `event`)
- Changed test setup from `beforeAll` to `beforeEach` for proper test isolation
- Added `expect.hasAssertions()` to all test cases for stricter assertion checking
- Updated global references from `window` to `globalThis` for better compatibility

### Refactoring Details
- Removed unused imports from Globe component (CameraOptions, layer types, React hooks)
- Simplified Globe component by delegating focus and layer logic to custom hooks
- Improved test organization in `globe.spec.tsx` by extracting `expectCountryBounds` helper function
- Updated atom exports in `state/atoms.ts` to use explicit export list instead of individual exports
- Improved code organization in `utils/test.ts` and `models/enums.ts` with explicit exports

### Minor Fixes
- Fixed `useWindow` hook to return `globalThis` instead of `Window` type
- Reordered imports in `use-match-media.ts` for consistency
- Reordered vite config properties for better organization

https://claude.ai/code/session_01GiJ7minoe2PFe1MGj2JuzP