### PR TITLE
style: enable import sorting in oxfmt

### DIFF
--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./node_modules/oxfmt/configuration_schema.json",
+  "sortImports": true
+}

--- a/src/components/app.spec.tsx
+++ b/src/components/app.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { mockMediaQueryList } from "../utils/test";
 import { App } from "./app";
 

--- a/src/components/app.tsx
+++ b/src/components/app.tsx
@@ -2,6 +2,7 @@ import classNames from "classnames";
 import { useSetAtom } from "jotai";
 import { memo, useCallback, useEffect, useState } from "react";
 import type { FC } from "react";
+
 import { rawCountriesAtom } from "../state/atoms.ts";
 import { Globe } from "./globe";
 import { Menu } from "./menu";

--- a/src/components/globe-focus.spec.tsx
+++ b/src/components/globe-focus.spec.tsx
@@ -3,6 +3,7 @@ import { Provider, createStore } from "jotai";
 import { Map as MapboxMap } from "mapbox-gl";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { MockInstance } from "vitest";
+
 import type { Country } from "../models/country";
 import { addCountryAtom, rawCountriesAtom, removeCountryAtom } from "../state/atoms";
 import { mockMediaQueryList } from "../utils/test";

--- a/src/components/globe.spec.tsx
+++ b/src/components/globe.spec.tsx
@@ -2,6 +2,7 @@ import { render } from "@testing-library/react";
 import { bbox, featureCollection } from "@turf/turf";
 import { createRef } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
 import { countries } from "../data/countries";
 import type { Country } from "../models/country";
 import { MapboxSourceKeys } from "../models/enums";

--- a/src/components/globe.tsx
+++ b/src/components/globe.tsx
@@ -1,14 +1,16 @@
 import { useAtomValue } from "jotai";
-import "mapbox-gl/dist/mapbox-gl.css";
 import { forwardRef, memo, useImperativeHandle, useRef } from "react";
 import { Layer, Map, NavigationControl, Source } from "react-map-gl/mapbox";
 import type { MapRef } from "react-map-gl/mapbox";
+
 import { useFocusCamera } from "../hooks/use-focus-camera";
 import { useGlobeLayers } from "../hooks/use-globe-layers";
 import { useMatchMedia } from "../hooks/use-match-media";
 import { MapboxLayerKeys, MapboxSourceKeys } from "../models/enums";
 import { focusAtom, selectedCountriesAtom } from "../state/atoms.ts";
 import type { ForwardedRefFunction } from "../types/utils";
+
+import "mapbox-gl/dist/mapbox-gl.css";
 
 const apiKeyMapbox = import.meta.env["VITE_API_KEY_MAPBOX"];
 const testMode = import.meta.env.MODE === "test";

--- a/src/components/menu-body.tsx
+++ b/src/components/menu-body.tsx
@@ -1,5 +1,6 @@
 import { memo } from "react";
 import type { FC } from "react";
+
 import type { Region } from "../models/region";
 import { MenuItem } from "./menu-item";
 import { Progress } from "./progress";

--- a/src/components/menu-item.spec.tsx
+++ b/src/components/menu-item.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
 import { MenuItem } from "./menu-item";
 
 describe("menuItem", () => {

--- a/src/components/menu-item.tsx
+++ b/src/components/menu-item.tsx
@@ -1,6 +1,7 @@
 import { useSetAtom } from "jotai";
 import { memo, useCallback } from "react";
 import type { FC } from "react";
+
 import type { Country } from "../models/country";
 import { addCountryAtom, removeCountryAtom } from "../state/atoms";
 

--- a/src/components/menu.spec.tsx
+++ b/src/components/menu.spec.tsx
@@ -1,6 +1,7 @@
 import { cleanup, render } from "@testing-library/react";
 import { Provider } from "jotai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
 import type { Country } from "../models/country.ts";
 import { rawCountriesAtom } from "../state/atoms.ts";
 import { HydrateAtoms } from "../utils/test.ts";

--- a/src/components/menu.tsx
+++ b/src/components/menu.tsx
@@ -1,6 +1,7 @@
 import { useAtomValue } from "jotai";
 import { memo, useId, useMemo, useState } from "react";
 import type { FC } from "react";
+
 import type { Region } from "../models/region";
 import { regionsAtom } from "../state/atoms.ts";
 import { MenuBody } from "./menu-body";

--- a/src/components/progress.spec.tsx
+++ b/src/components/progress.spec.tsx
@@ -1,5 +1,6 @@
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
 import { Progress } from "./progress";
 
 describe("progress", () => {

--- a/src/hooks/use-focus-camera.ts
+++ b/src/hooks/use-focus-camera.ts
@@ -1,7 +1,8 @@
+import type { CameraOptions } from "mapbox-gl";
 import { useCallback, useEffect, useRef } from "react";
 import type { RefObject } from "react";
-import type { CameraOptions } from "mapbox-gl";
 import type { MapRef, ViewStateChangeEvent } from "react-map-gl/mapbox";
+
 import type { Focus } from "../models/focus";
 
 // Frames the focused country, and returns the `onMoveStart` handler that lets the user's own

--- a/src/hooks/use-globe-layers.ts
+++ b/src/hooks/use-globe-layers.ts
@@ -1,5 +1,5 @@
-import { useMemo } from "react";
 import type { FillExtrusionLayerSpecification, FillLayerSpecification } from "mapbox-gl";
+import { useMemo } from "react";
 
 type Filter = NonNullable<FillExtrusionLayerSpecification["filter"]>;
 

--- a/src/hooks/use-local-storage.spec.ts
+++ b/src/hooks/use-local-storage.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+
 import { useLocalStorage } from "./use-local-storage";
 
 describe("useLocalStorage", () => {

--- a/src/hooks/use-local-storage.ts
+++ b/src/hooks/use-local-storage.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
+
 import { useWindow } from "./use-window";
 
 export const useLocalStorage = <Value>(

--- a/src/hooks/use-match-media.spec.ts
+++ b/src/hooks/use-match-media.spec.ts
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+
 import { mockMediaQueryList } from "../utils/test";
 import { useMatchMedia } from "./use-match-media";
 

--- a/src/hooks/use-match-media.ts
+++ b/src/hooks/use-match-media.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo, useSyncExternalStore } from "react";
+
 import { useWindow } from "./use-window";
 
 export const useMatchMedia = (query: string): boolean => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+
 import { App } from "./components/app";
+
 import "./styles.css";
 
 const container = document.querySelector("#app");

--- a/src/state/atoms.spec.ts
+++ b/src/state/atoms.spec.ts
@@ -1,5 +1,6 @@
 import { createStore } from "jotai";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
 import type { Country } from "../models/country";
 import { addCountryAtom, focusAtom, rawCountriesAtom, removeCountryAtom } from "./atoms";
 

--- a/src/state/atoms.ts
+++ b/src/state/atoms.ts
@@ -1,5 +1,6 @@
 import { atom } from "jotai";
 import { atomWithStorage } from "jotai/utils";
+
 import type { Country } from "../models/country.ts";
 import type { Focus } from "../models/focus.ts";
 import type { Region } from "../models/region.ts";

--- a/src/utils/regionalizr.spec.ts
+++ b/src/utils/regionalizr.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+
 import type { Country } from "../models/country";
 import type { Region } from "../models/region";
 import { regionalizer } from "./regionalizer";

--- a/src/utils/test.ts
+++ b/src/utils/test.ts
@@ -1,6 +1,6 @@
-import type { PropsWithChildren, ReactNode } from "react";
 import type { WritableAtom } from "jotai/index";
 import { useHydrateAtoms } from "jotai/utils";
+import type { PropsWithChildren, ReactNode } from "react";
 import { vi } from "vitest";
 
 // oxlint-disable-next-line no-explicit-any -- Any is required to allow any atom type. Unfortunately cannot be `unknown`.


### PR DESCRIPTION
Adds `.oxfmtrc.json` with `sortImports` turned on, so the formatter owns import order instead of it being convention that nothing checked. `pnpm run format` already runs in CI, so this is enforced from here on.

```json
{
  "$schema": "./node_modules/oxfmt/configuration_schema.json",
  "sortImports": true
}
```

This is the whole config — oxfmt's defaults already match what the codebase does by hand: group as builtin → external → internal → parent/sibling/index → styles, alphabetical within a group, blank line between groups.

## What the reformat touched

Most of the 22 files only gain a blank line between their package imports and their relative ones. Three files had external imports that were not actually alphabetical, and get reordered:

- `use-focus-camera.ts` — `mapbox-gl` moves above `react`
- `use-globe-layers.ts` — same
- `utils/test.ts` — the `react` type import moves below `jotai/*`

## The one judgement call

`globe.tsx` imports the mapbox stylesheet, and side-effect imports are not sorted by default because their order can be significant. Left where it was, mid-group, it just earned a stray blank line after `jotai`:

```ts
import { useAtomValue } from "jotai";

import "mapbox-gl/dist/mapbox-gl.css";
import { forwardRef, memo, useImperativeHandle, useRef } from "react";
```

So it moves to the end of the block instead, matching how `index.tsx` already imports `styles.css`. This does not change when it is evaluated: `index.tsx` imports the app before its own styles either way, so the mapbox base styles still load first and app styles can still override them.

## Interaction with oxlint

`eslint/sort-imports` keeps `ignoreDeclarationSort: true`. oxfmt does not sort named specifiers, so the lint rule still covers that half, and its own declaration ordering puts multiple-specifier imports before single ones — which would fight the formatter.

## Checks

`pnpm run lint`, `tsc --noEmit` and `pnpm run format --check` all pass, and the formatter is idempotent on the result.

I could not run `pnpm test` — vitest uses browser mode and this sandbox has Playwright browser build 1194 against the pinned `playwright@1.62`, which wants 1234, so no test files execute. CI installs its own Chromium, so it will cover them. Nothing here changes runtime behaviour: it is import order plus one relocated stylesheet import.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KfaFiMZSL1Dn3qgtC9KsMX)_